### PR TITLE
Fix bt_ci_workflow_isolated_unit_tests.yml

### DIFF
--- a/.github/workflows/bt_ci_workflow_isolated_unit_tests.yml
+++ b/.github/workflows/bt_ci_workflow_isolated_unit_tests.yml
@@ -84,6 +84,7 @@ jobs:
   job2:
     name: ${{ matrix.value }}
     needs: job1
+    if: ${{ needs.job1.outputs.matrix != '[]' }}
     strategy:
       matrix:
         value: ${{fromJSON(needs.job1.outputs.matrix)}}


### PR DESCRIPTION
With this fix, I would like to prevent the error that occurs when there is no module to test isolated.
https://github.com/brain-tec/ptec/actions/runs/3687574629
![error_without_isolated_tests](https://user-images.githubusercontent.com/10939126/207403506-86991faa-2373-41e1-9337-79ca77f29f4c.png)

After applying this fix, a check without isolated UnitTests would look like this:
https://github.com/brain-tec/ptec/actions/runs/3687672600
![success_without_isolated_tests](https://user-images.githubusercontent.com/10939126/207403763-f3bce40e-24d3-4b67-b44b-916e5f2a420d.png)

![pr_success_without_isolated_tests](https://user-images.githubusercontent.com/10939126/207403794-6669c8e7-f232-471e-8306-41f3033facc5.png)

After applying this fix, a check with isolated UnitTests would look like this:
https://github.com/brain-tec/ptec/actions/runs/3687761082
![success_with_isolated_tests](https://user-images.githubusercontent.com/10939126/207403866-fdad4f6e-669e-44d2-af49-5e5c7d823348.png)

![pr_success_with_isolated_tests](https://user-images.githubusercontent.com/10939126/207403890-ed1a72f0-0059-4954-95e5-51c62224ef36.png)

